### PR TITLE
Improve efficiency of readBulk buffer reading

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -84,24 +84,27 @@ func readLine(r Reader) (line string, err error) {
 func readBulk(r Reader) (interface{}, error) {
 	var bs []byte
 
-	num_bytes, err := ReadNumber(r)
+	numBytes, err := ReadNumber(r)
 	if err != nil {
 		return nil, err
 	}
 
-	if num_bytes == -1 {
+	if numBytes == -1 {
 		return nil, nil
 	}
 
-	bs = make([]byte, num_bytes)
-	b := make([]byte, 1)
+	bs = make([]byte, numBytes)
+	n := int64(0)
 
-	for i := int64(0); i < num_bytes; i++ {
-		_, err = r.Read(b)
+	for {
+		bytesRead, err := r.Read(bs)
+		n += int64(bytesRead)
+
 		if err != nil {
 			return nil, err
+		} else if n == numBytes {
+			break
 		}
-		bs[i] = b[0]
 	}
 
 	// Must read following two bytes for \r\n


### PR DESCRIPTION
The previous implementation was reading 1 byte at a time and then
copying it to a target buffer. Now it reads as many bytes as
possible into the target buffer up to the byte length.

Also changed num_bytes to numBytes as it was probably a Ruby typo
